### PR TITLE
fix getting started example

### DIFF
--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -84,7 +84,7 @@ The builder should be configured with the local node configuration:
 
 ```java
 
-builder.withId("member1")
+builder.withMemberId("member1")
   .withAddress("10.192.19.181")
   .build();
 ```


### PR DESCRIPTION
This PR fixes an example in the getting started guide. The method `withId` does not exist, I assumed you mean `withMemberId`.

Greets
Chris